### PR TITLE
export the iframe element instead of the content window

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function getSource(url) {
     '  iframe.addEventListener(\'load\', injectScript);\n' +
     '}\n' +
     'document.body.appendChild(iframe);\n' +
-    'module.exports = iframe.contentWindow;';
+    'module.exports = iframe;';
 }
 
 function getCompilation(loader) {


### PR DESCRIPTION
Export the iframe element instead of the content window so we can use it in our external application/manager script. for example showing and hiding the iframe.
